### PR TITLE
Add Node.js support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,21 @@ setTimeout(ws.reconnect, 10e3);
 ```
 
 
+## Node.js usage
+
+Using the [`ws`](https://github.com/websockets/ws) module as underlying client.
+
+```js
+const WebSocket = require('ws');
+const Sockette = require('sockette');
+
+const ws = new Sockette('ws://localhost:3000', {
+  // Regular options
+  WebSocket
+});
+```
+
+
 ## API
 
 ### Sockette(url, options)
@@ -138,6 +153,13 @@ The `EventListener` to run in response to `'error'` events. It receives the `Eve
 > This is called anytime an error occurs.
 
 > **Important:** If the `event.code` is `ECONNREFUSED`, an automatic reconnect attempt will be queued.
+
+#### options.WebSocket
+Type: `Function`
+
+The `WebSocket` constructor to use. Defaults to global `WebSocket` otherwise.
+
+> This is mostly for Node.js where there's no global `WebSocket` object.
 
 ### send(data)
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export default function (url, opts) {
 
 	let k, ws, num, $={}, self=this;
 	let ms=opts.timeout || 1e3, max=opts.maxAttempts || Infinity;
+	let WebSocketConstructor = opts.WebSocket || WebSocket
 
 	$.onmessage = opts.onmessage || noop;
 
@@ -22,7 +23,7 @@ export default function (url, opts) {
 	};
 
 	self.open = () => {
-		ws = new WebSocket(url, opts.protocols);
+		ws = new WebSocketConstructor(url, opts.protocols);
 		for (k in $) ws[k] = $[k];
 	};
 


### PR DESCRIPTION
Currently Sockette depends on a global WebSocket constructor, which is not the case when used on Node.js.

This PR adds `options.WebSocket` to allow passing a custom WebSocket constructor, for example from the `ws` module.