### PR TITLE
protocols fallback when undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default function (url, opts) {
 	};
 
 	self.open = () => {
-		ws = new WebSocket(url, opts.protocols);
+		ws = new WebSocket(url, opts.protocols || []);
 		for (k in $) ws[k] = $[k];
 	};
 


### PR DESCRIPTION
On the latest Firefox and Edge versions, with the current version of sockette.js, the usage of `opts.protocols` without any check causes the browser to send `undefined` in the `Sec-WebSocket-Protocol` header.

Protocol being the string `undefined`, the server is likely to send a `426: No Sec-WebSocket-Protocols requested supported` (except if you specify on your server side that 'undefined' is a possible protocol value).

Passing `[]` to the WebSocket constructor instead of `undefined` nullify the need for protocol check on the server side, as browsers stop sending the header.