### PR TITLE
Update url param to be dynamic if needed

### DIFF
--- a/sockette.d.ts
+++ b/sockette.d.ts
@@ -1,6 +1,6 @@
 declare module "sockette" {
 	export default class Sockette {
-		constructor(url: string, options?: SocketteOptions);
+		constructor(url: string | Promise<string> | ((attempt: number) => Promise<string>) | ((attempt: number) => string), options?: SocketteOptions);
 		send(data: any): void;
 		json(data: any): void;
 		close(code?: number, reason?: string): void;


### PR DESCRIPTION
As requested by issue #59 my use case is the same. I need to pass a token on every connection attempt and it's only possible to use the token once. So the url must change on every reconnect attempt. 

If url param is a function invoke it passing the attempt number

Solution:
Change the url param to be of type:
```javascript
- string
- Promise<string>
- (attempt: number) => Promise<string>
- (attempt: number) => string
```

So the usage would look like:
```javascript
// string as it is now
new Sockette('wss://address')
// promise style. just adding the setTimeout to simulate
new Sockette(new Promise((resolve) => {
  setTimeout(() => {
    resolve('wss://address')
  }, 5000)
}))

new Sockette(Promise.resolve('wss://address'))

new Sockette((attempt) => `wss://address?attempt${attempt}`)

new Sockette(async (attempt) => await Promise.resolve(`wss://address?attempt${attempt}`))
```