### PR TITLE
Change initial Sockette.timer value from 1 to -1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ function noop() {}
 export default function (url, opts) {
 	opts = opts || {};
 
-	var ws, num=0, timer=1, $={};
+	var ws, num=0, timer=-1, $={};
 	var max = opts.maxAttempts || Infinity;
 
 	$.open = function () {


### PR DESCRIPTION
This PR fixes the issue described in #66  by setting `timer` value to `-1` which would still enable normal functionality of `Sockette.reconnect`, but at the same time, it will not by mistake clear any other timeouts/intervals.

Closes #66 